### PR TITLE
feat: add Level 11 - The Diner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import LevelSevenPage from './pages/07_LevelSevenPage/LevelSeven';
 import LevelEightPage from './pages/08_LevelEightPage/LevelEightPage';
 import LevelNinePage from './pages/09_LevelNinePage/LevelNinePage';
 import LevelTenPage from './pages/10_LevelTenPage/LevelTenPage';
+import LevelElevenPage from './pages/11_LevelElevenPage/LevelElevenPage';
 function App() {
     return (
         <BrowserRouter>
@@ -33,6 +34,7 @@ function App() {
                             <Route path="8" element={<LevelEightPage />} />
                             <Route path="9" element={<LevelNinePage />} />
                             <Route path="10" element={<LevelTenPage />} />
+                            <Route path="11" element={<LevelElevenPage />} />
                             {/* Add new levels here */}
                         </Route>
 

--- a/src/pages/11_LevelElevenPage/LevelElevenPage.css
+++ b/src/pages/11_LevelElevenPage/LevelElevenPage.css
@@ -1,0 +1,51 @@
+.level-11-custom-input {
+    display: flex;
+    align-items: center;
+    grid-column: 1 / -1;
+    gap: 0.5rem;
+}
+
+.level-11-custom-input input {
+    flex: 1;
+    padding: 12px 16px;
+    border: 2px solid #e0e0e0;
+    border-radius: var(--radius-sm);
+    font-size: 1rem;
+    outline: none;
+    transition: border-color 0.2s ease;
+    background: white;
+    color: #333;
+    text-align: center;
+}
+
+.level-11-custom-input input:focus {
+    border-color: var(--secondary-color, #6c63ff);
+}
+
+.level-11-custom-input input::placeholder {
+    color: #aaa;
+    font-style: italic;
+}
+
+.level-11-apply-button {
+    padding: 12px 20px;
+    background: var(--secondary-gradient);
+    color: white;
+    border: none;
+    border-radius: var(--radius-sm);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.level-11-apply-button:hover {
+    transform: scale(1.05);
+    box-shadow: var(--shadow-md);
+}
+
+.level-11-apply-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    transform: none;
+}

--- a/src/pages/11_LevelElevenPage/LevelElevenPage.tsx
+++ b/src/pages/11_LevelElevenPage/LevelElevenPage.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import TipButton from '../../components/TipButton/TipButton';
+import TipView from '../../components/TipView/TipView';
+import LevelOverModal from '../../components/LevelOverModal/LevelOverModal';
+import './LevelElevenPage.css';
+import '../shared/LevelPages.css';
+import levelData from '../meta/levels.json';
+import toast from 'react-hot-toast';
+import { MdChat } from 'react-icons/md';
+
+const LevelElevenPage: React.FC = () => {
+    const [selectedTip, setSelectedTip] = useState<number | null>(null);
+    const [showLevelOverModal, setShowLevelOverModal] = useState(false);
+    const [customText, setCustomText] = useState('');
+    const [isCustomActive, setIsCustomActive] = useState(false);
+    const level = levelData.levels[10];
+    const baseAmount = level.baseAmount;
+    const navigate = useNavigate();
+
+    const handleTipSelect = (percentage: number) => {
+        setSelectedTip(percentage);
+        setIsCustomActive(false);
+        setCustomText('');
+    };
+
+    const handleCustomApply = () => {
+        if (!customText.trim()) return;
+
+        if (customText === 'ZERO') {
+            setSelectedTip(0);
+            setIsCustomActive(true);
+            toast.success("Well played.", { icon: <MdChat /> });
+        } else if (customText.toLowerCase() === 'zero') {
+            toast.error("Hmm... that's not quite right. Try being more... AGGRESSIVE.", {
+                icon: <MdChat />,
+            });
+        } else {
+            const parsed = parseFloat(customText);
+            if (!isNaN(parsed) && parsed >= 0) {
+                setSelectedTip(Math.max(parsed, 1));
+                setIsCustomActive(true);
+            } else {
+                toast.error("I don't understand that. Try typing a number... or something else.", {
+                    icon: <MdChat />,
+                });
+            }
+        }
+    };
+
+    const handleSubmit = () => {
+        localStorage.setItem('level11Tip', selectedTip?.toString() || '0');
+        setShowLevelOverModal(true);
+    };
+
+    const handleModalClose = () => {
+        setShowLevelOverModal(false);
+        navigate('/');
+    };
+
+    return (
+        <motion.div
+            className="level-container"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+        >
+            <h1 className="level-title">{level.title}</h1>
+            <p className="level-subtitle">{level.subtitle}</p>
+            <div className="tip-container">
+                <TipView baseAmount={baseAmount} tipPercentage={selectedTip} />
+                <motion.div
+                    className="tip-buttons"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: 0.2 }}
+                >
+                    <TipButton
+                        percentage={10}
+                        onClick={handleTipSelect}
+                        isSelected={selectedTip === 10 && !isCustomActive}
+                    />
+                    <TipButton
+                        percentage={15}
+                        onClick={handleTipSelect}
+                        isSelected={selectedTip === 15 && !isCustomActive}
+                    />
+                    <TipButton
+                        percentage={18}
+                        onClick={handleTipSelect}
+                        isSelected={selectedTip === 18 && !isCustomActive}
+                    />
+                    <TipButton
+                        percentage={20}
+                        onClick={handleTipSelect}
+                        isSelected={selectedTip === 20 && !isCustomActive}
+                    />
+                    <motion.div
+                        className="level-11-custom-input"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ delay: 0.3 }}
+                    >
+                        <input
+                            type="text"
+                            value={customText}
+                            onChange={(e) => setCustomText(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') handleCustomApply();
+                            }}
+                            placeholder="Type your tip..."
+                        />
+                        <button
+                            className="level-11-apply-button"
+                            onClick={handleCustomApply}
+                            disabled={!customText.trim()}
+                        >
+                            Apply
+                        </button>
+                    </motion.div>
+                </motion.div>
+                <motion.button
+                    className="submit-button"
+                    onClick={handleSubmit}
+                    disabled={selectedTip === null}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: 0.3 }}
+                >
+                    Submit Tip
+                </motion.button>
+            </div>
+
+            <LevelOverModal isOpen={showLevelOverModal} tipPercentage={selectedTip ?? 0} onClose={handleModalClose} />
+        </motion.div>
+    );
+};
+
+export default LevelElevenPage;

--- a/src/pages/meta/levels.json
+++ b/src/pages/meta/levels.json
@@ -59,6 +59,12 @@
       "title": "The Bank",
       "subtitle": "You're approved for a loan! After you sign there, it's just going to ask you a couple questions...",
       "baseAmount": 10000.00
+    },
+    {
+      "id": 11,
+      "title": "The Diner",
+      "subtitle": "Great meal! Now it's just going to ask you a couple questions...",
+      "baseAmount": 34.50
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add new Level 11 ("The Diner") page and route
- Register level metadata in `levels.json` with a base amount of $34.50
- Wire up `LevelElevenPage` component and `/11` route in `App.tsx`

<!-- emdash-issue-footer:start -->
Fixes #14
<!-- emdash-issue-footer:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated UI/route additions plus a new `localStorage` key; no changes to shared auth/protection or critical data flows.
> 
> **Overview**
> Adds a new playable Level 11 ("The Diner") to the app by registering it in `levels.json` and wiring `/level/11` to a new `LevelElevenPage` route.
> 
> `LevelElevenPage` introduces a custom tip input alongside preset tip buttons, including special-case handling for the text `ZERO`, and persists the chosen value to `localStorage` (`level11Tip`) before showing the existing level-over modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b74db864ab962717c32d88ee750e0a045ad80fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->